### PR TITLE
Add and fix test for dom event driven http app, closes #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jquery": "^2.1.4",
     "mocha": "^2.3.4",
     "mochify": "^2.14.3",
-    "rx": "^4.0.7"
+    "rx": "^4.0.7",
+    "superagent-mock": "git://github.com/Widdershin/superagent-mock"
   }
 }

--- a/src/restart.js
+++ b/src/restart.js
@@ -1,7 +1,8 @@
 import {run} from '@cycle/core';
 
-export default function restart (main, sources, drivers, isolate = {}) {
+export default function restart (main, drivers, {sources, sinks}, isolate = {}) {
   sources.dispose();
+  sinks && sinks.dispose();
 
   if ('reset' in isolate) {
     isolate.reset();
@@ -25,6 +26,14 @@ export default function restart (main, sources, drivers, isolate = {}) {
         const history = sources[driverName].history();
 
         driver.replayHistory(history);
+      }
+    }
+
+    for (let driverName in drivers) {
+      const driver = drivers[driverName];
+
+      if (driver.replayFinished) {
+        driver.replayFinished();
       }
     }
   });

--- a/test/browser/dom-http-test.js
+++ b/test/browser/dom-http-test.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import {run} from '@cycle/core';
 import {button, makeDOMDriver} from '@cycle/dom';
 
-const request = require('superagent');
+const request = require('../../node_modules/@cycle/http/node_modules/superagent');
 
 let requestCount = 0;
 

--- a/test/browser/dom-http-test.js
+++ b/test/browser/dom-http-test.js
@@ -1,0 +1,100 @@
+
+/* globals describe, it, before, after */
+import assert from 'assert';
+import {run} from '@cycle/core';
+import {button, makeDOMDriver} from '@cycle/dom';
+
+const request = require('superagent');
+
+let requestCount = 0;
+
+const config = [
+  {
+    pattern: '/',
+
+    fixtures: function (match, params, headers) {
+      return 'Hello, world! - ' + ++requestCount;
+    },
+
+    get: function (match, data) {
+      return {text: data};
+    }
+  }
+];
+
+const superagentMock = require('superagent-mock')(request, config);
+
+import {makeHTTPDriver} from '@cycle/http';
+
+import restart from '../../src/restart';
+
+import {Observable} from 'rx';
+
+import $ from 'jquery';
+
+let testContainerCount = 34534;
+
+function makeTestContainer () {
+  const selector = 'test-' + testContainerCount;
+  const container = $(`<div class="${selector}">`);
+
+  $(document.body).append(container);
+
+  testContainerCount++;
+
+  return {container, selector: '.' + selector};
+}
+
+describe('restarting a cycle app that makes http requests trigged by dom events', () => {
+  function main ({DOM, HTTP}) {
+    const responses$ = HTTP.mergeAll().map(res => res.text);
+    const click$ = DOM.select('.click').events('click');
+
+    return {
+      DOM: Observable.just(button('.click', 'Click me!')),
+      HTTP: click$.map(_ => '/'),
+      responses$
+    };
+  }
+
+  it('replays responses', (done) => {
+    const {container, selector} = makeTestContainer();
+
+    const drivers = {
+      HTTP: makeHTTPDriver({eager: true}),
+      DOM: makeDOMDriver(selector)
+    };
+
+    assert.equal(requestCount, 0);
+
+    const {sources, sinks} = run(main, drivers);
+
+    setTimeout(() => {
+      $('.click').click();
+
+      let responseText;
+
+      sinks.responses$.take(1).subscribe(text => {
+        responseText = text;
+        assert.equal(text, 'Hello, world! - 1');
+
+        assert.equal(
+          requestCount, 1,
+          `Expected requestCount to be 1 prior to restart, was ${requestCount}.`
+        );
+
+        const restartedSinks = restart(main, drivers, {sources}).sinks;
+
+        restartedSinks.responses$.take(1).subscribe(text => {
+          assert.equal(text, 'Hello, world! - 1');
+          assert.equal(
+            requestCount, 1,
+            `Expected requestCount to be 1 after restart, was ${requestCount}.`
+          );
+
+          done();
+        });
+      });
+    }, 50);
+  });
+});

--- a/test/browser/dom-test.js
+++ b/test/browser/dom-test.js
@@ -75,7 +75,7 @@ describe('restarting a cycle app', () => {
 
       assert.equal(container.find('.count').text(), 3);
 
-      restart(newMain, sources, drivers);
+      restart(newMain, drivers, {sources});
 
       setTimeout(() => {
         assert.equal(container.find('.count').text(), 6);
@@ -104,7 +104,7 @@ describe('restarting a cycle app', () => {
 
       assert.equal(container.find('.count').text(), 3);
 
-      restart(main, sources, drivers);
+      restart(main, drivers, {sources});
 
       setTimeout(() => {
         assert.equal(container.find('.count').text(), 3);
@@ -115,7 +115,7 @@ describe('restarting a cycle app', () => {
 
         assert.equal(container.find('.count').text(), 6);
 
-        restart(main, sources, drivers);
+        restart(main, drivers, {sources});
 
         setTimeout(() => {
           assert.equal(container.find('.count').text(), 6);
@@ -177,7 +177,7 @@ describe('restarting a cycle app with multiple streams', () => {
 
       assert.equal(container.find('.count').text(), 0);
 
-      restart(main, sources, drivers);
+      restart(main, drivers, {sources});
 
       setTimeout(() => {
         assert.equal(container.find('.count').text(), 0);

--- a/test/browser/isolation-test.js
+++ b/test/browser/isolation-test.js
@@ -84,7 +84,7 @@ describe('scoped components', () => {
 
       assert.equal(container.text(), '0+-3+-');
 
-      restart(main, sources, drivers, isolate);
+      restart(main, drivers, {sources}, isolate);
 
       setTimeout(() => {
         assert.equal(container.text(), '0+-3+-');

--- a/test/node/http-test.js
+++ b/test/node/http-test.js
@@ -48,7 +48,7 @@ describe('restarting a cycle app that makes http requests', () => {
         `Expected requestCount to be 1 prior to restart, was ${requestCount}.`
       );
 
-      restart(main, sources, drivers);
+      restart(main, drivers, {sources});
 
       setTimeout(() => {
         assert.equal(
@@ -81,7 +81,7 @@ describe('restarting a cycle app that makes http requests', () => {
           `Expected requestCount to be 1 prior to restart, was ${requestCount}.`
         );
 
-        const restartedSinks = restart(main, sources, drivers).sinks;
+        const restartedSinks = restart(main, drivers, {sources}).sinks;
 
         restartedSinks.responses$.take(1).subscribe(text => {
           assert.equal(text, 'Hello, world! - 1');


### PR DESCRIPTION
- Change API to take into sinks so they can be disposed
- Add a callback, replayFinished, because replayHistory isn't very
  useful to @cycle/http
- Mock out requests using superagent-mock (had to implement abort
  support, fun)