### PR TITLE
Feature/memory stream error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,16 +7,19 @@
       "version": "17.4.0",
       "resolved": "https://registry.npmjs.org/@cycle/dom/-/dom-17.4.0.tgz",
       "integrity": "sha1-Iy6fITI7NLJEAA4PoKBnZCrpBdI=",
+      "dev": true,
       "dependencies": {
         "snabbdom": {
           "version": "0.6.9",
           "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.6.9.tgz",
-          "integrity": "sha1-ZaOS9Mgsp+jscqoNL6eXz1xzuNc="
+          "integrity": "sha1-ZaOS9Mgsp+jscqoNL6eXz1xzuNc=",
+          "dev": true
         },
         "snabbdom-selector": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/snabbdom-selector/-/snabbdom-selector-1.2.0.tgz",
-          "integrity": "sha1-QmCiadnUb1C5wfOdpijCr2go3VM="
+          "integrity": "sha1-QmCiadnUb1C5wfOdpijCr2go3VM=",
+          "dev": true
         }
       }
     },
@@ -62,11 +65,13 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@cycle/run/-/run-3.1.0.tgz",
       "integrity": "sha1-dt9YKlAdLRuHH49t7PJjr64JA4Q=",
+      "dev": true,
       "dependencies": {
         "xstream": {
           "version": "10.8.0",
           "resolved": "https://registry.npmjs.org/xstream/-/xstream-10.8.0.tgz",
-          "integrity": "sha1-88cLEqce803MavROp+GwxA0yD08="
+          "integrity": "sha1-88cLEqce803MavROp+GwxA0yD08=",
+          "dev": true
         }
       }
     },
@@ -960,7 +965,8 @@
     "cssauron": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg="
+      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
+      "dev": true
     },
     "custom-error-instance": {
       "version": "2.1.1",
@@ -970,7 +976,8 @@
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -1079,7 +1086,8 @@
     "es5-ext": {
       "version": "0.10.21",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.21.tgz",
-      "integrity": "sha1-Gacl+eUdAwC7wejoIRCf2dr1WSU="
+      "integrity": "sha1-Gacl+eUdAwC7wejoIRCf2dr1WSU=",
+      "dev": true
     },
     "es5-shim": {
       "version": "4.5.9",
@@ -1090,22 +1098,26 @@
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA="
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE="
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1122,7 +1134,8 @@
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true
     },
     "events": {
       "version": "1.1.1",
@@ -3389,7 +3402,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.3",

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -1,4 +1,4 @@
-import xs, { MemoryStream } from 'xstream';
+import xs from 'xstream';
 
 function pausable (pause$) {
   return function (stream) {

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -149,11 +149,10 @@ export default function restartable (driver, opts = {}) {
 
   function restartableDriver (sink$, Time) {
     const filteredSink$ = xs.create();
-    const isReplayingOnlyLastSink = isReplaying() && replayOnlyLastSink
     let lastSinkEvent$ = xs.createWithMemory();
 
     if (sink$) {
-      if (isReplayingOnlyLastSink)  {
+      if (isReplaying() && replayOnlyLastSink)  {
         lastSinkEvent$.map(lastEvent => finishedReplay$.mapTo(lastEvent)).flatten().take(1).addListener(subscribe((event) => {
           filteredSink$.shamefullySendNext(event);
         }));
@@ -170,8 +169,10 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
-    if (isReplayingOnlyLastSink && !(sink$ instanceof MemoryStream)) {
+    if (!(sink$ instanceof MemoryStream)) {
       lastSinkEvent$.imitate(sink$);
+    } else {
+      lastSinkEvent$.imitate(sink$.filter(() => {}));
     }
 
     const source = driver(filteredSink$);

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -169,6 +169,8 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
+    // force sink$ to a normal stream with .filter() to prevent attempting
+    // imitation of a MemoryStream which can't be imitated
     lastSinkEvent$.imitate(sink$.filter(() => {}));
 
     const source = driver(filteredSink$);

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -149,10 +149,11 @@ export default function restartable (driver, opts = {}) {
 
   function restartableDriver (sink$, Time) {
     const filteredSink$ = xs.create();
+    const isReplayingOnlyLastSink = isReplaying() && replayOnlyLastSink
     let lastSinkEvent$ = xs.createWithMemory();
 
     if (sink$) {
-      if (isReplaying() && replayOnlyLastSink)  {
+      if (isReplayingOnlyLastSink)  {
         lastSinkEvent$.map(lastEvent => finishedReplay$.mapTo(lastEvent)).flatten().take(1).addListener(subscribe((event) => {
           filteredSink$.shamefullySendNext(event);
         }));
@@ -169,9 +170,7 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
-    if (sink$ instanceof MemoryStream) {
-      lastSinkEvent$ = sink$
-    } else {
+    if (isReplayingOnlyLastSink && !(sink$ instanceof MemoryStream)) {
       lastSinkEvent$.imitate(sink$);
     }
 

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -169,11 +169,7 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
-    if (!(sink$ instanceof MemoryStream)) {
-      lastSinkEvent$.imitate(sink$);
-    } else {
-      lastSinkEvent$.imitate(sink$.filter(() => {}));
-    }
+    lastSinkEvent$.imitate(sink$.filter(() => {}));
 
     const source = driver(filteredSink$);
 

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -169,9 +169,11 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
-    // force sink$ to a normal stream with .filter() to prevent attempting
-    // imitation of a MemoryStream which can't be imitated
-    lastSinkEvent$.imitate(sink$.filter(() => {}));
+    if (sink$) {
+      // force sink$ to a normal stream with .filter() to prevent attempting
+      // imitation of a MemoryStream which can't be imitated
+      lastSinkEvent$.imitate(sink$.filter(() => true));
+    }
 
     const source = driver(filteredSink$);
 

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -1,4 +1,4 @@
-import xs from 'xstream';
+import xs, { MemoryStream } from 'xstream';
 
 function pausable (pause$) {
   return function (stream) {
@@ -149,7 +149,7 @@ export default function restartable (driver, opts = {}) {
 
   function restartableDriver (sink$, Time) {
     const filteredSink$ = xs.create();
-    const lastSinkEvent$ = xs.createWithMemory();
+    let lastSinkEvent$ = xs.createWithMemory();
 
     if (sink$) {
       if (isReplaying() && replayOnlyLastSink)  {
@@ -169,7 +169,11 @@ export default function restartable (driver, opts = {}) {
       }
     }
 
-    lastSinkEvent$.imitate(sink$);
+    if (sink$ instanceof MemoryStream) {
+      lastSinkEvent$ = sink$
+    } else {
+      lastSinkEvent$.imitate(sink$);
+    }
 
     const source = driver(filteredSink$);
 

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -149,7 +149,7 @@ export default function restartable (driver, opts = {}) {
 
   function restartableDriver (sink$, Time) {
     const filteredSink$ = xs.create();
-    let lastSinkEvent$ = xs.createWithMemory();
+    const lastSinkEvent$ = xs.createWithMemory();
 
     if (sink$) {
       if (isReplaying() && replayOnlyLastSink)  {


### PR DESCRIPTION
I was getting an error in my application because my DOM driver `sink$` was somehow getting converted to a `MemoryStream` which caused an uncaught exception to be thrown by `xstream` when attempting to call `lastSinkEvent$.imitate(sink$)`.

I noticed that `lastSinkEvent$` is only ever actually used to figure out when to call `shamefullySendNext()` on `filteredSink$` in situations where `(isReplaying() && replayOnlyLastSink)` so I tried wrapping the imitate in that same condition and it seems to work fine. I'm unsure of the actual use-case for `replayOnlyLastSink` so wasn't able to test it by hand but my changes haven't broken any tests.