### PR TITLE
Support symbol properties on wrapped streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@cycle/time": "^0.8.0",
+    "get-own-property-symbols": "^0.9.2",
     "xstream": "^10.8.0"
   }
 }

--- a/src/restartable.js
+++ b/src/restartable.js
@@ -1,4 +1,5 @@
 import xs from 'xstream';
+import 'get-own-property-symbols';
 
 function pausable (pause$) {
   return function (stream) {
@@ -57,7 +58,8 @@ function wrapSourceFunction ({streams, addLogEntry, pause$, Time}, name, f, cont
 
     const returnValue = f.bind(context, ...args)();
 
-    if (name.indexOf('isolate') !== -1 || typeof returnValue !== 'object') {
+    /* Not all names will be strings, some may be symbols. */
+    if (typeof name === 'string' && name.indexOf('isolate') !== -1 || typeof returnValue !== 'object') {
       return returnValue;
     }
 
@@ -74,7 +76,17 @@ function wrapSourceFunction ({streams, addLogEntry, pause$, Time}, name, f, cont
 function keys (obj) {
   const _keys = [];
 
-  for (let prop in obj) {
+  for (const prop in obj) {
+    _keys.push(prop);
+  }
+
+  /* Expose all symbol properties as keys. */
+  for(const prop of Object.getOwnPropertySymbols(obj) ) {
+    _keys.push(prop);
+  }
+
+  /* Expose all prototype sybmol properties as keys. */
+  for(const prop of Object.getOwnPropertySymbols(Object.getPrototypeOf(obj) || {}) ) {
     _keys.push(prop);
   }
 

--- a/test/browser/symbol-test.js
+++ b/test/browser/symbol-test.js
@@ -1,0 +1,22 @@
+/* globals describe, it*/
+import assert from 'assert';
+import {run} from '@cycle/run';
+import {adapt} from '@cycle/run/lib/adapt';
+import {makeDOMDriver} from '@cycle/dom';
+import {rerunner, restartable} from '../../src/restart';
+import xs from 'xstream';
+
+describe('restartable', () => {
+  const symbol = Symbol( 'test' );
+
+  function driver( ) {
+    return {
+      [ symbol ]: 'example',
+    };
+  }
+
+  it('should preserve symbols', () => {
+    const sink = restartable( driver )();
+    assert.equal( sink[ symbol ], 'example' );
+  });
+});

--- a/test/node/symbol-test.js
+++ b/test/node/symbol-test.js
@@ -1,0 +1,22 @@
+/* globals describe, it*/
+import assert from 'assert';
+import {run} from '@cycle/run';
+import {adapt} from '@cycle/run/lib/adapt';
+import {makeDOMDriver} from '@cycle/dom';
+import {rerunner, restartable} from '../../src/restart';
+import xs from 'xstream';
+
+describe('restartable', () => {
+  const symbol = Symbol( 'test' );
+
+  function driver( ) {
+    return {
+      [ symbol ]: 'example',
+    };
+  }
+
+  it('should preserve symbols', () => {
+    const sink = restartable( driver )();
+    assert.equal( sink[ symbol ], 'example' );
+  });
+});


### PR DESCRIPTION
Ensure properties that are symbols are included in streams wrapped by cycle-restart.

Many stream libraries are using symbols to standardize interoperability between one another. When transforming streams as part of cycle-restart, it is important to retain all behavior that is present on the stream or on its prototype.

This change includes a shim for Object.getOwnPropertySymbols, which is used to retrieve all symbols from an object.

Resolves #67.